### PR TITLE
Added sdks section to tcf.json

### DIFF
--- a/tcf.json
+++ b/tcf.json
@@ -30,5 +30,15 @@
       "domain": "turbo.adsbynimbus.com",
       "use": "Impression tracking"
     }
+  ],
+  "sdks": [
+    {
+      "name": "com.adsbynimbus.android",
+      "use": "Advertising"
+    },
+    {
+      "name": "NimbusKit.framework",
+      "use": "Advertising"
+    }
   ]
 }


### PR DESCRIPTION
Adds the [tcf.json sdks section](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/Vendor%20Device%20Storage%20%26%20Operational%20Disclosures.md#sdks-array) to fix a compliance issue flagged by IAB Europe.

```json
"sdks": [
  {
    "name": "com.adsbynimbus.android", 
    "use": "Advertising"
  },
  {
    "name": "NimbusKit.framework",
    "use": "Advertising"
  }
]
```